### PR TITLE
 availability_topic for Home assistant

### DIFF
--- a/switchbot_mqtt/__init__.py
+++ b/switchbot_mqtt/__init__.py
@@ -27,11 +27,11 @@ from switchbot_mqtt._actors.base import _MQTTCallbackUserdata
 
 _LOGGER = logging.getLogger(__name__)
 
-_MQTT_AVAILABILITY_TOPIC="switchbot_mqtt/status"
+_MQTT_AVAILABILITY_TOPIC = "switchbot_mqtt/status"
 # "online" and "offline" to match home assistant's default settings
 # https://www.home-assistant.io/integrations/switch.mqtt/#payload_available
-_MQTT_BIRTH_PAYLOAD="online"
-_MQTT_LAST_WILL_PAYLOAD="offline"
+_MQTT_BIRTH_PAYLOAD = "online"
+_MQTT_LAST_WILL_PAYLOAD = "offline"
 
 
 def _mqtt_on_connect(
@@ -52,8 +52,12 @@ def _mqtt_on_connect(
         else mqtt_broker_host,
         mqtt_broker_port,
     )
-    _availability_topic_with_prefix = userdata.mqtt_topic_prefix + _MQTT_AVAILABILITY_TOPIC
-    mqtt_client.publish(topic=_availability_topic_with_prefix,payload=_MQTT_BIRTH_PAYLOAD)
+    _availability_topic_with_prefix = (
+        userdata.mqtt_topic_prefix + _MQTT_AVAILABILITY_TOPIC
+    )
+    mqtt_client.publish(
+        topic=_availability_topic_with_prefix, payload=_MQTT_BIRTH_PAYLOAD
+    )
     _ButtonAutomator.mqtt_subscribe(mqtt_client=mqtt_client, settings=userdata)
     _CurtainMotor.mqtt_subscribe(mqtt_client=mqtt_client, settings=userdata)
 
@@ -93,7 +97,9 @@ def _run(
     elif mqtt_password:
         raise ValueError("Missing MQTT username")
     _availability_topic_with_prefix = mqtt_topic_prefix + _MQTT_AVAILABILITY_TOPIC
-    mqtt_client.will_set(topic=_availability_topic_with_prefix,payload=_MQTT_LAST_WILL_PAYLOAD)
+    mqtt_client.will_set(
+        topic=_availability_topic_with_prefix, payload=_MQTT_LAST_WILL_PAYLOAD
+    )
     mqtt_client.connect(host=mqtt_host, port=mqtt_port)
     # https://github.com/eclipse/paho.mqtt.python/blob/master/src/paho/mqtt/client.py#L1740
     mqtt_client.loop_forever()

--- a/switchbot_mqtt/__init__.py
+++ b/switchbot_mqtt/__init__.py
@@ -31,7 +31,7 @@ _MQTT_AVAILABILITY_TOPIC="switchbot_mqtt/availability"
 # "online" and "offline" to match home assistant's default settings
 # https://www.home-assistant.io/integrations/switch.mqtt/#payload_available
 _MQTT_BIRTH_PAYLOAD="online"
-LWT="offline"
+_MQTT_LAST_WILL_PAYLOAD="offline"
 
 
 def _mqtt_on_connect(

--- a/switchbot_mqtt/__init__.py
+++ b/switchbot_mqtt/__init__.py
@@ -27,7 +27,7 @@ from switchbot_mqtt._actors.base import _MQTTCallbackUserdata
 
 _LOGGER = logging.getLogger(__name__)
 
-availability_topic="switchbot_mqtt/availability"
+_MQTT_AVAILABILITY_TOPIC="switchbot_mqtt/availability"
 BirthMessage="online"
 LWT="offline"
 

--- a/switchbot_mqtt/__init__.py
+++ b/switchbot_mqtt/__init__.py
@@ -27,7 +27,7 @@ from switchbot_mqtt._actors.base import _MQTTCallbackUserdata
 
 _LOGGER = logging.getLogger(__name__)
 
-ConnectionTopic="switchbot_mqtt/availability"
+availability_topic="switchbot_mqtt/availability"
 BirthMessage="online"
 LWT="offline"
 
@@ -50,7 +50,7 @@ def _mqtt_on_connect(
         else mqtt_broker_host,
         mqtt_broker_port,
     )
-    mqtt_client.publish(topic=ConnectionTopic,payload=BirthMessage)
+    mqtt_client.publish(topic=availability_topic,payload=BirthMessage)
     _ButtonAutomator.mqtt_subscribe(mqtt_client=mqtt_client, settings=userdata)
     _CurtainMotor.mqtt_subscribe(mqtt_client=mqtt_client, settings=userdata)
 
@@ -89,7 +89,7 @@ def _run(
         mqtt_client.username_pw_set(username=mqtt_username, password=mqtt_password)
     elif mqtt_password:
         raise ValueError("Missing MQTT username")
-    mqtt_client.will_set(topic=ConnectionTopic,payload=LWT)
+    mqtt_client.will_set(topic=availability_topic,payload=LWT)
     mqtt_client.connect(host=mqtt_host, port=mqtt_port)
     # https://github.com/eclipse/paho.mqtt.python/blob/master/src/paho/mqtt/client.py#L1740
     mqtt_client.loop_forever()

--- a/switchbot_mqtt/__init__.py
+++ b/switchbot_mqtt/__init__.py
@@ -27,7 +27,7 @@ from switchbot_mqtt._actors.base import _MQTTCallbackUserdata
 
 _LOGGER = logging.getLogger(__name__)
 
-_MQTT_AVAILABILITY_TOPIC="switchbot_mqtt/availability"
+_MQTT_AVAILABILITY_TOPIC="switchbot_mqtt/status"
 # "online" and "offline" to match home assistant's default settings
 # https://www.home-assistant.io/integrations/switch.mqtt/#payload_available
 _MQTT_BIRTH_PAYLOAD="online"

--- a/switchbot_mqtt/__init__.py
+++ b/switchbot_mqtt/__init__.py
@@ -28,7 +28,9 @@ from switchbot_mqtt._actors.base import _MQTTCallbackUserdata
 _LOGGER = logging.getLogger(__name__)
 
 _MQTT_AVAILABILITY_TOPIC="switchbot_mqtt/availability"
-BirthMessage="online"
+# "online" and "offline" to match home assistant's default settings
+# https://www.home-assistant.io/integrations/switch.mqtt/#payload_available
+_MQTT_BIRTH_PAYLOAD="online"
 LWT="offline"
 
 

--- a/switchbot_mqtt/__init__.py
+++ b/switchbot_mqtt/__init__.py
@@ -27,6 +27,10 @@ from switchbot_mqtt._actors.base import _MQTTCallbackUserdata
 
 _LOGGER = logging.getLogger(__name__)
 
+ConnectionTopic="switchbot_mqtt/availability"
+BirthMessage="online"
+LWT="offline"
+
 
 def _mqtt_on_connect(
     mqtt_client: paho.mqtt.client.Client,
@@ -46,6 +50,7 @@ def _mqtt_on_connect(
         else mqtt_broker_host,
         mqtt_broker_port,
     )
+    mqtt_client.publish(topic=ConnectionTopic,payload=BirthMessage)
     _ButtonAutomator.mqtt_subscribe(mqtt_client=mqtt_client, settings=userdata)
     _CurtainMotor.mqtt_subscribe(mqtt_client=mqtt_client, settings=userdata)
 
@@ -84,6 +89,7 @@ def _run(
         mqtt_client.username_pw_set(username=mqtt_username, password=mqtt_password)
     elif mqtt_password:
         raise ValueError("Missing MQTT username")
+    mqtt_client.will_set(topic=ConnectionTopic,payload=LWT)
     mqtt_client.connect(host=mqtt_host, port=mqtt_port)
     # https://github.com/eclipse/paho.mqtt.python/blob/master/src/paho/mqtt/client.py#L1740
     mqtt_client.loop_forever()

--- a/switchbot_mqtt/__init__.py
+++ b/switchbot_mqtt/__init__.py
@@ -56,7 +56,7 @@ def _mqtt_on_connect(
         userdata.mqtt_topic_prefix + _MQTT_AVAILABILITY_TOPIC
     )
     mqtt_client.publish(
-        topic=_availability_topic_with_prefix, payload=_MQTT_BIRTH_PAYLOAD
+        topic=_availability_topic_with_prefix, payload=_MQTT_BIRTH_PAYLOAD, retain=True
     )
     _ButtonAutomator.mqtt_subscribe(mqtt_client=mqtt_client, settings=userdata)
     _CurtainMotor.mqtt_subscribe(mqtt_client=mqtt_client, settings=userdata)
@@ -98,7 +98,9 @@ def _run(
         raise ValueError("Missing MQTT username")
     _availability_topic_with_prefix = mqtt_topic_prefix + _MQTT_AVAILABILITY_TOPIC
     mqtt_client.will_set(
-        topic=_availability_topic_with_prefix, payload=_MQTT_LAST_WILL_PAYLOAD
+        topic=_availability_topic_with_prefix,
+        payload=_MQTT_LAST_WILL_PAYLOAD,
+        retain=True,
     )
     mqtt_client.connect(host=mqtt_host, port=mqtt_port)
     # https://github.com/eclipse/paho.mqtt.python/blob/master/src/paho/mqtt/client.py#L1740

--- a/switchbot_mqtt/__init__.py
+++ b/switchbot_mqtt/__init__.py
@@ -52,7 +52,8 @@ def _mqtt_on_connect(
         else mqtt_broker_host,
         mqtt_broker_port,
     )
-    mqtt_client.publish(topic=availability_topic,payload=BirthMessage)
+    _availability_topic_with_prefix = userdata.mqtt_topic_prefix + _MQTT_AVAILABILITY_TOPIC
+    mqtt_client.publish(topic=_availability_topic_with_prefix,payload=_MQTT_BIRTH_PAYLOAD)
     _ButtonAutomator.mqtt_subscribe(mqtt_client=mqtt_client, settings=userdata)
     _CurtainMotor.mqtt_subscribe(mqtt_client=mqtt_client, settings=userdata)
 
@@ -91,7 +92,8 @@ def _run(
         mqtt_client.username_pw_set(username=mqtt_username, password=mqtt_password)
     elif mqtt_password:
         raise ValueError("Missing MQTT username")
-    mqtt_client.will_set(topic=availability_topic,payload=LWT)
+    _availability_topic_with_prefix = mqtt_topic_prefix + _MQTT_AVAILABILITY_TOPIC
+    mqtt_client.will_set(topic=_availability_topic_with_prefix,payload=_MQTT_LAST_WILL_PAYLOAD)
     mqtt_client.connect(host=mqtt_host, port=mqtt_port)
     # https://github.com/eclipse/paho.mqtt.python/blob/master/src/paho/mqtt/client.py#L1740
     mqtt_client.loop_forever()


### PR DESCRIPTION
With this PR a Birth message and a Will message is set. 
Upon connection the message "online" is published to switchbot_mqtt/availability and upon loosing connection (KeepAlve Timeout or job was killed) the Will publishes "offline" to the same topic.
For the mqtt sensors in home assistant you can set the  availability_topic to this topic and then you can check if the service is running or not.

If you want we could add a CLI Option to set this topic to have different topics for multiple Instances.